### PR TITLE
OCMAKU-435 Change cost effectiveness heading to "tender vs award amount" in public portal

### DIFF
--- a/web/public/languages/en_US.json
+++ b/web/public/languages/en_US.json
@@ -100,7 +100,7 @@
   "charts:costEffectiveness:traces:difference": "Difference",
   "charts:costEffectiveness:xAxisTitle": "Year",
   "charts:costEffectiveness:yAxisTitle": "Amount",
-  "charts:costEffectiveness:title": "Cost effectiveness (estimated amount - award amount)",
+  "charts:costEffectiveness:title": "Tender amount vs Award amount",
   "charts:general:noData": "No data",
   "charts:nrCancelled:title": "Number of cancelled invitations to bid",
   "charts:nrCancelled:xAxisTitle": "Year",


### PR DESCRIPTION
Change cost effectiveness heading to "tender vs award amount" in public portal